### PR TITLE
Handle auth and data errors

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -19,6 +19,7 @@ from data_processing import *
 from styling import *
 
 # for export
+import logging
 import io
 import flask
 

--- a/src/app.py
+++ b/src/app.py
@@ -42,6 +42,10 @@ app = Dash(__name__,
                 requests_pathname_prefix=os.environ.get("REQUESTS_PATHNAME_PREFIX", "/"),
                 suppress_callback_exceptions=True
                 )
+gunicorn_logger = logging.getLogger('gunicorn.error')
+app.logger = logging.getLogger("weekly_ui")
+app.logger.handlers = gunicorn_logger.handlers
+app.logger.setLevel(logging.INFO)
 
 
 # ----------------------------------------------------------------------------
@@ -474,10 +478,21 @@ def serve_layout():
 
         # Get data from API
         api_address = DATASTORE_URL + 'subjects'
-        print(api_address)
+        app.logger.info('Requesting data from api {0}'.format(api_address))
         api_json = get_api_data(api_address)
 
         # subjects_json = get_subjects_json(report, report_suffix, file_url_root, source=DATA_SOURCE)
+        if 'error' in api_json:
+            app.logger.info('Error response from datastore: {0}'.format(api_json))
+            if 'error_code' in api_json:
+                error_code = api_json['error_code']
+                if error_code in ('MISSING_SESSION_ID', 'INVALID_TAPIS_TOKEN'):
+                    raise PortalAuthException
+
+        # If data is not available, try with bypassing cache and see if that works.
+        if not api_json or 'data' not in api_json:
+            app.logger.info('Requesting data from api {0} to bypass cache.'.format(api_address))
+            api_json = get_api_data(api_address, True)
 
         if api_json:
             subjects = pd.DataFrame.from_dict(api_json['data']['subjects_cleaned'])
@@ -514,6 +529,9 @@ def serve_layout():
         sections_dict['section4'] = section4
 
         page_layout = html.Div(id='page_layout')
+    except PortalAuthException:
+        app.logger.warn('Auth error from datastore, asking user to authenticate')
+        page_layout = html.Div([html.H4('Please login and authenticate on the portal to access the report.')])
     except Exception as e:
         traceback.print_exc()
         page_layout = html.Div(['There has been a problem accessing the data for this Report.'])

--- a/src/app.py
+++ b/src/app.py
@@ -532,10 +532,10 @@ def serve_layout():
         page_layout = html.Div(id='page_layout')
     except PortalAuthException:
         app.logger.warn('Auth error from datastore, asking user to authenticate')
-        page_layout = html.Div([html.H4('Please login and authenticate on the portal to access the report.')])
+        return html.Div([html.H4('Please login and authenticate on the portal to access the report.')],style=TACC_IFRAME_SIZE)
     except Exception as e:
         traceback.print_exc()
-        page_layout = html.Div(['There has been a problem accessing the data for this Report.'])
+        return html.Div(['There has been a problem accessing the data for this Report.'],style=TACC_IFRAME_SIZE)
 
     s_layout = html.Div([
         dcc.Store(id='store_meta', data = page_meta_dict),

--- a/src/datastore_loading.py
+++ b/src/datastore_loading.py
@@ -1,33 +1,33 @@
 import os
 import flask
 import requests
-import json
-import traceback
+import logging
+
 
 # ---------------------------------
 #   MOVE THIS TO REFERENCE FROM ENV
 # ---------------------------------
 DATASTORE_URL = os.environ.get("DATASTORE_URL","url not found")
 DATASTORE_URL = os.path.join(DATASTORE_URL, "api/")
+logger  = logging.getLogger("imaging_app")
 
 # ---------------------------------
 #   Get Data From datastore
 # ---------------------------------
 
-def get_api_data(api_address):
+class PortalAuthException(Exception):
+    '''Custom Exception for issues with Authentication'''
+
+def get_api_data(api_address, ignore_cache=False):
     api_json = {}
     try:
-        try:
-            response = requests.get(api_address, cookies=flask.request.cookies)
-        except:
-            return('error: {}'.format(e))
-        request_status = response.status_code
-        if request_status == 200:
-            api_json = response.json()
-            return api_json
-        else:
-            return request_status
+        params = {}
+        if ignore_cache:
+            params = {'ignore_cache':True}
+        response = requests.get(api_address, params=params, cookies=flask.request.cookies)
+        response.raise_for_status()
+        return response.json()
     except Exception as e:
-        traceback.print_exc()
+        logger.warn(e)
         api_json['json'] = 'error: {}'.format(e)
         return api_json


### PR DESCRIPTION
## Overview
When authentication fails or user is not authenticated, provide a message to user to authenticate in the portal
When data is invalid, try again by bypassing cache.
## Related
Corresponding change: https://github.com/TACC/a2cps-datastore/pull/8

## Testing
Try it out at: https://dev.a2cps.tacc.utexas.edu/reports/weekly-report-latest/
delete coresessionid cookie in dev tools to simulate session issue.